### PR TITLE
Alter script for Ubuntu Noble Numbat 24.04

### DIFF
--- a/user_data.sh
+++ b/user_data.sh
@@ -1,25 +1,10 @@
 #!/usr/bin/env bash
 
-##############
-# Install deps
-##############
+################
+# Install AWSCLI
+################
 
-# Apt based distro
-if command -v apt-get &>/dev/null; then
-  apt-get update
-  apt-get install python3-pip jq -y
-
-# Yum based distro
-elif command -v yum &>/dev/null; then
-  yum update -y
-  # epel provides python-pip & jq
-  yum install -y epel-release
-  yum install python3-pip jq -y
-fi
-
-#####################
-
-pip3 install --upgrade awscli
+snap install aws-cli --classic
 
 ##############
 


### PR DESCRIPTION
The parent of this repo is no longer being maintained, so I'm removing support for Redhat based distributions. We're using Ubuntu anyway.

The current way to install awscli on Ubuntu is to use the snap package manager, because we all need more package managers. At least pip is dead.

Tested and working as intended.